### PR TITLE
Fix IR badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Download](https://search.maven.org/artifact/com.github.ojaynico/ojaynico-kotlin-react-native-navigation/1.0.5/pom)
 
-![https://kotl.in/jsirsupported](https://img.shields.io/badge/Kotlin%2FJS-IR%20supported-yellow)
+[![Kotlin JS IR supported](https://img.shields.io/badge/Kotlin%2FJS-IR%20supported-yellow)](https://kotl.in/jsirsupported)
 
 Kotlin wrappers for react-native-navigation by wix and react-native-navigation-drawer-extension
 


### PR DESCRIPTION
I made a small mistake when announcing the badge on Slack, this fixes the link 🎉

